### PR TITLE
Function call revamp

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -1885,11 +1885,10 @@ static int compile_right_assoc_binary(struct cstate *state)
 
 static int compile_call_expression(struct cstate *state)
 {
-	size_t num_args;
 	int first_arg;
 
 	EXPECT(TOK_LEFT_PAREN);
-	num_args = 0;
+	APPEND(OP_PREP_FOR_CALL);
 
 	first_arg = 1;
 	while (!MATCH_P(TOK_RIGHT_PAREN)) {
@@ -1901,13 +1900,11 @@ static int compile_call_expression(struct cstate *state)
 				break;
 		}
 
-		num_args += 1;
 		X(compile_expression(state));
 	}
 	EXPECT(TOK_RIGHT_PAREN);
 
 	APPEND(OP_CALL);
-	APPEND_SIZE_T(num_args);
 
 	return 0;
 }

--- a/disassemble.c
+++ b/disassemble.c
@@ -42,7 +42,7 @@ int cb_disassemble_one(cb_bytecode *bytecode, size_t pc)
 #define NEXT_USIZE() ({ \
 		size_t result = 0; \
 		for (int _i = 0; _i < sizeof(size_t) / sizeof(cb_instruction); _i += 1) \
-			result += NEXT() << (_i * 8 * sizeof(cb_instruction)); \
+			result += ((size_t) NEXT()) << (_i * 8 * sizeof(cb_instruction)); \
 		result; \
 	})
 #define WITH_ARGS(NARGS) (1 + sizeof(size_t) / sizeof(cb_instruction) * (NARGS))
@@ -120,7 +120,7 @@ int cb_disassemble_one(cb_bytecode *bytecode, size_t pc)
 		arg2 = NEXT_USIZE();
 		arg3 = NEXT_USIZE();
 		printf("%s(\"%s\", %zu, %zu)\n", cb_opcode_name(op),
-				(arg1 == (size_t) -1 - 1)
+				arg1 == -1
 				? "<anonymous>"
 				: cb_strptr(cb_agent_get_string(arg1)),
 				arg2, arg3);

--- a/disassemble.c
+++ b/disassemble.c
@@ -77,10 +77,8 @@ int cb_disassemble_one(cb_bytecode *bytecode, size_t pc)
 	case OP_NEG:
 	case OP_END_MODULE:
 	case OP_DUP:
-	case OP_RETURN:
 	case OP_EXIT_MODULE:
 	case OP_PREP_FOR_CALL:
-	case OP_CALL:
 		printf("%s\n", cb_opcode_name(op));
 		return WITH_ARGS(0);
 
@@ -103,6 +101,8 @@ int cb_disassemble_one(cb_bytecode *bytecode, size_t pc)
 	case OP_EXPORT:
 	case OP_ENTER_MODULE:
 	case OP_NEW_ARRAY_WITH_VALUES:
+	case OP_RETURN:
+	case OP_CALL:
 		printf("%s(%zu)\n", cb_opcode_name(op), NEXT_USIZE());
 		return WITH_ARGS(1);
 

--- a/disassemble.c
+++ b/disassemble.c
@@ -79,6 +79,8 @@ int cb_disassemble_one(cb_bytecode *bytecode, size_t pc)
 	case OP_DUP:
 	case OP_RETURN:
 	case OP_EXIT_MODULE:
+	case OP_PREP_FOR_CALL:
+	case OP_CALL:
 		printf("%s\n", cb_opcode_name(op));
 		return WITH_ARGS(0);
 
@@ -101,7 +103,6 @@ int cb_disassemble_one(cb_bytecode *bytecode, size_t pc)
 	case OP_EXPORT:
 	case OP_ENTER_MODULE:
 	case OP_NEW_ARRAY_WITH_VALUES:
-	case OP_CALL:
 		printf("%s(%zu)\n", cb_opcode_name(op), NEXT_USIZE());
 		return WITH_ARGS(1);
 

--- a/eval.c
+++ b/eval.c
@@ -499,7 +499,7 @@ DO_OP_CALL: {
 			goto end;
 		}
 		stack_diff = actual_stack_effect - expected_stack_effect;
-		while (stack_diff--)
+		while (stack_diff > 0 && --stack_diff)
 			POP();
 	}
 

--- a/intrinsics.c
+++ b/intrinsics.c
@@ -43,6 +43,7 @@
 	X(array_length, 1) \
 	X(truncate32, 1) \
 	X(tofloat, 1) \
+	X(toint, 1) \
 	X(read_file, 1) \
 	X(argv, 0) \
 	X(upvalues, 0) \
@@ -334,6 +335,16 @@ static int truncate32(size_t argc, struct cb_value *argv,
 
 	*result = argv[0];
 	result->val.as_int = result->val.as_int & 0xFFFFFFFF;
+
+	return 0;
+}
+
+static int toint(size_t argc, struct cb_value *argv, struct cb_value *result)
+{
+	EXPECT_TYPE(CB_VALUE_DOUBLE, argv[0]);
+
+	result->type = CB_VALUE_INT;
+	result->val.as_int = (uint64_t) argv[0].val.as_double;
 
 	return 0;
 }

--- a/lib/hashmap.rbcvm
+++ b/lib/hashmap.rbcvm
@@ -5,7 +5,7 @@ import "assoclist.rbcvm";
 import "hash.rbcvm";
 import "string.rbcvm";
 
-let INITIAL_CAPACITY = 2 ** 3;
+let INITIAL_CAPACITY = toint(1 ** 3);
 let LOAD_FACTOR = 0.7;
 
 # hashmap

--- a/opcode.h
+++ b/opcode.h
@@ -55,6 +55,7 @@
 	X(OP_ALLOCATE_LOCALS) \
 	X(OP_ENTER_MODULE) \
 	X(OP_EXIT_MODULE) \
+	X(OP_PREP_FOR_CALL) \
 	X(OP_MAX)
 
 enum cb_opcode {


### PR DESCRIPTION
Closes #8 

This PR removes the static argument count and replaces it with a dynamic calculation at runtime.

- [x] Dynamic tracking of number of arguments
- [ ] Multiple return values (and multiple assignment)
- [ ] Splatting array into arguments