### PR TITLE
Userdata type

### DIFF
--- a/intrinsics.c
+++ b/intrinsics.c
@@ -9,6 +9,7 @@
 #include "hashmap.h"
 #include "intrinsics.h"
 #include "value.h"
+#include "userdata.h"
 
 #define FUNC(FN, ARITY) ({ \
 		struct cb_function *_func; \

--- a/userdata.c
+++ b/userdata.c
@@ -1,0 +1,15 @@
+#include <stddef.h>
+
+#include "alloc.h"
+#include "userdata.h"
+
+inline void **cb_userdata_ptr(struct cb_userdata *data)
+{
+	return (void **) &data->userdata;
+}
+
+struct cb_userdata *cb_userdata_new(size_t size,
+		cb_userdata_deinit_fn *deinit_fn)
+{
+	return cb_malloc(sizeof(struct cb_userdata) + size, deinit_fn);
+}

--- a/userdata.h
+++ b/userdata.h
@@ -1,0 +1,19 @@
+#ifndef cb_userdata_h
+#define cb_userdata_h
+
+#include <stddef.h>
+
+#include "gc.h"
+
+typedef void (cb_userdata_deinit_fn)(void *user_data);
+
+struct cb_userdata {
+	cb_gc_header gc_header;
+	unsigned char userdata[];
+};
+
+void **cb_userdata_ptr(struct cb_userdata *ud);
+struct cb_userdata *cb_userdata_new(size_t size,
+		cb_userdata_deinit_fn *deinit_fn);
+
+#endif

--- a/value.c
+++ b/value.c
@@ -25,6 +25,12 @@ static void adjust_refcount(struct cb_value *value, int amount)
 	case CB_VALUE_FUNCTION:
 		header = &value->val.as_function->gc_header;
 		break;
+	case CB_VALUE_STRUCT:
+		header = &value->val.as_struct->gc_header;
+		break;
+	case CB_VALUE_USERDATA:
+		header = &value->val.as_userdata->gc_header;
+		break;
 
 	default:
 		return;
@@ -129,6 +135,8 @@ int cb_value_is_truthy(struct cb_value *val)
 		return 0;
 	case CB_VALUE_STRUCT:
 	case CB_VALUE_STRUCT_SPEC:
+		return 1;
+	case CB_VALUE_USERDATA:
 		return 1;
 	}
 	return 0;
@@ -332,6 +340,14 @@ char *cb_value_to_string(struct cb_value *val)
 		break;
 	}
 
+	case CB_VALUE_USERDATA: {
+		size_t size = sizeof("<userdata>");
+		buf = malloc(size);
+		buf[size - 1] = 0;
+		memcpy(buf, "<userdata>", size - 1);
+		break;
+	}
+
 	default:
 		fprintf(stderr, "unsupported to_string\n");
 		abort();
@@ -408,6 +424,8 @@ int cb_value_eq(struct cb_value *a, struct cb_value *b)
 		}
 		return 1;
 	}
+	case CB_VALUE_USERDATA:
+		return a->val.as_userdata == b->val.as_userdata;
 	default:
 		return 0;
 	}
@@ -503,6 +521,8 @@ const char *cb_value_type_friendly_name(enum cb_value_type typ)
 		return "struct";
 	case CB_VALUE_STRUCT_SPEC:
 		return "struct spec";
+	case CB_VALUE_USERDATA:
+		return "userdata";
 	}
 
 	return "";
@@ -542,6 +562,7 @@ void cb_value_mark(struct cb_value *val)
 	case CB_VALUE_NULL:
 	case CB_VALUE_INTERNED_STRING:
 	case CB_VALUE_STRUCT_SPEC:
+	case CB_VALUE_USERDATA:
 		return;
 
 	case CB_VALUE_STRING:

--- a/value.h
+++ b/value.h
@@ -5,6 +5,7 @@
 
 #include "gc.h"
 #include "string.h"
+#include "userdata.h"
 
 #define CB_VALUE_IS_USER_FN(V) ((V)->type == CB_VALUE_FUNCTION \
 		&& (V)->val.as_function->type == CB_FUNCTION_USER)
@@ -20,7 +21,8 @@
 	X(CB_VALUE_ARRAY) \
 	X(CB_VALUE_FUNCTION) \
 	X(CB_VALUE_STRUCT_SPEC) \
-	X(CB_VALUE_STRUCT)
+	X(CB_VALUE_STRUCT) \
+	X(CB_VALUE_USERDATA)
 
 enum cb_value_type {
 #define COMMA(V) V,
@@ -80,6 +82,7 @@ struct cb_value {
 		/* the struct spec is not garbage collected; it needs to have a
 		   lifetime as long as the VM */
 		const struct cb_struct_spec *as_struct_spec;
+		struct cb_userdata *as_userdata;
 	} val;
 };
 


### PR DESCRIPTION
This PR adds a type that can hold arbitrary values.

An example usage is also included, where a `FILE *` object is stored in the userdata. This allows for managing foreign values with the VM and garbage collector without having to add every type to the type system.

To identify the type of userdata object, I propose just using the `deinit` attribute of the `cb_gc_header` stored in every userdata object.