### PR TITLE
C modules

### DIFF
--- a/agent.c
+++ b/agent.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "agent.h"
+#include "builtin_modules.h"
 #include "module.h"
 #include "string.h"
 #include "struct.h"
@@ -48,6 +49,8 @@ void cb_agent_init(void)
 #ifdef DEBUG_VM
 	agent.finished_compiling = 0;
 #endif
+
+	cb_initialize_builtin_modules();
 }
 
 void cb_agent_deinit(void)

--- a/builtin_modules.c
+++ b/builtin_modules.c
@@ -1,0 +1,46 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "agent.h"
+#include "builtin_modules.h"
+#include "eval.h"
+#include "hashmap.h"
+#include "module.h"
+
+const size_t cb_builtin_module_count = 0;
+struct cb_builtin_module_spec builtins[cb_builtin_module_count] = {};
+struct cb_builtin_module_spec *cb_builtin_modules = builtins;
+
+void cb_initialize_builtin_modules(void)
+{
+	cb_modspec *modspec;
+
+	for (size_t i = 0; i < cb_builtin_module_count; i += 1) {
+		modspec = cb_modspec_new(cb_agent_intern_string(
+					builtins[i].name,
+					strlen(builtins[i].name)));
+		builtins[i].build_spec(modspec);
+		cb_agent_add_modspec(modspec);
+	}
+}
+
+void cb_instantiate_builtin_modules(void)
+{
+	cb_modspec *spec;
+	size_t spec_id;
+	struct cb_builtin_module_spec *builtin;
+	struct cb_module *mod;
+
+	for (size_t i = 0; i < cb_builtin_module_count; i += 1) {
+		builtin = &builtins[i];
+		spec = cb_agent_get_modspec_by_name(
+				cb_agent_intern_string(builtin->name,
+					strlen(builtin->name)));
+		spec_id = cb_modspec_id(spec);
+		mod = &cb_vm_state.modules[spec_id];
+
+		mod->global_scope = cb_hashmap_new();
+		mod->spec = spec;
+		builtin->instantiate(mod);
+	}
+}

--- a/builtin_modules.h
+++ b/builtin_modules.h
@@ -1,0 +1,18 @@
+#ifndef cb_builtin_modules_h
+#define cb_builtin_modules_h
+
+#include "module.h"
+
+struct cb_builtin_module_spec {
+	const char *name;
+	void (*build_spec)(cb_modspec *);
+	void (*instantiate)(struct cb_module *);
+};
+
+const size_t cb_builtin_module_count;
+struct cb_builtin_module_spec *cb_builtin_modules;
+
+void cb_initialize_builtin_modules(void);
+void cb_instantiate_builtin_modules(void);
+
+#endif

--- a/eval.c
+++ b/eval.c
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "agent.h"
+#include "builtin_modules.h"
 #include "compiler.h"
 #include "eval.h"
 #include "hashmap.h"
@@ -38,6 +39,8 @@ void cb_vm_init(cb_bytecode *bytecode)
 			sizeof(struct cb_module));
 	cb_vm_state.globals = cb_hashmap_new();
 	make_intrinsics(cb_vm_state.globals);
+
+	cb_instantiate_builtin_modules();
 }
 
 void cb_vm_deinit(void)


### PR DESCRIPTION
Not a very elegant way to do this, but it works.

These native modules are static, like in CPython's Modules directory. They are compiled into the VM, not dynamically loaded from shared object files.

They are defined by a name (which is what it's imported as, and also the module name), a function to built the module spec (i.e. exports), and a function to make the module itself.

A simple example:

```c
#include "agent.h"
#include "module.h"
#include "value.h"

/* These function can be called whatever; they're referred to by function pointer */
void cmodule_build_spec(cb_modspec *spec) {
	cb_modspec_add_export(spec, cb_agent_intern_string("hello", 5));
}

void cmodule_instantiate(struct cb_module *mod) {
	struct cb_value val;
	val.type = CB_VALUE_STRING;
	val.val.as_string = cb_string_new();
	val.val.as_string->string = cb_str_from_cstr("Hello, World!", 13);

	cb_hashmap_set(mod->global_scope, cb_agent_intern_string("hello", 5), val);
}
```

In `builtin_modules.c`, an entry is added and `cb_builtin_module_count` is incremented:

```c
size_t cb_builtin_module_count = 1;
struct cb_builtin_module_spec builtins[cb_builtin_module_count] = {
	{"cmodule", cmodule_build_spec, cmodule_instantiate}
};
```

And now it can be used like so:

```rb
import "cmodule";  # note that there is no extension or qualification

println(cmodule.hello);  #=> Hello, World!
```