### PR TITLE
Better imports

### DIFF
--- a/agent.c
+++ b/agent.c
@@ -246,14 +246,15 @@ void cb_agent_set_finished_compiling()
    message will be printed.
 
    It is the caller's responsibility to close the returned file handle. */
-FILE *cb_agent_resolve_import(const char *import_name, size_t len,
-		const char *pwd, char **fname_out)
+FILE *cb_agent_resolve_import(cb_str import_name, const char *pwd,
+		char **fname_out)
 {
 #define min(A, B) ({ typeof((A)) _a = (A), _b = (B); _a < _b ? _a : _b; })
 #define CHECK_LEN ({ \
 		if (path[MAX_IMPORT_PATH_LEN - 1] != 0) { \
 			fprintf(stderr, "Import path for '%.*s' is too long\n", \
-					(int) len, import_name); \
+					(int) cb_strlen(import_name), \
+					cb_strptr(import_name)); \
 			return NULL; \
 		} \
 	})
@@ -271,10 +272,11 @@ FILE *cb_agent_resolve_import(const char *import_name, size_t len,
 		j = strlen(path);
 		assert(j + 1 < MAX_IMPORT_PATH_LEN);
 		path[j++] = '/';
-		strncpy(path + j, import_name,
-				min(MAX_IMPORT_PATH_LEN - j, len));
+		strncpy(path + j, cb_strptr(import_name), min(
+				MAX_IMPORT_PATH_LEN - j,
+				cb_strlen(import_name)));
 		CHECK_LEN;
-		j += len;
+		j += cb_strlen(import_name);
 		strncpy(path + j, ".rbcvm", MAX_IMPORT_PATH_LEN - j);
 		CHECK_LEN;
 
@@ -286,8 +288,9 @@ FILE *cb_agent_resolve_import(const char *import_name, size_t len,
 		return f;
 	}
 
-	fprintf(stderr, "Import '%.*s' not found, checked in: ", (int) len,
-			import_name);
+	fprintf(stderr, "Import '%.*s' not found, checked in: ",
+			(int) cb_strlen(import_name),
+			cb_strptr(import_name));
 	for (i = -1; i < MAX_IMPORT_PATHS && agent.import_paths[i]; i += 1) {
 		if (i > 0)
 			fputs(", ", stderr);

--- a/agent.h
+++ b/agent.h
@@ -2,12 +2,13 @@
 #define cb_agent_h
 
 #include <stddef.h>
+#include <stdio.h>
 
 #include "module.h"
 #include "str.h"
 #include "struct.h"
 
-void cb_agent_init(void);
+int cb_agent_init(void);
 void cb_agent_deinit(void);
 
 size_t cb_agent_intern_string(const char *str, size_t len);
@@ -19,6 +20,8 @@ cb_modspec *cb_agent_get_modspec_by_name(size_t name);
 size_t cb_agent_modspec_count(void);
 size_t cb_agent_add_struct_spec(struct cb_struct_spec spec);
 const struct cb_struct_spec *cb_agent_get_struct_spec(size_t id);
+FILE *cb_agent_resolve_import(const char *import_name, size_t len,
+		const char *pwd, char **fname_out);
 
 #ifdef DEBUG_VM
 void cb_agent_set_finished_compiling();

--- a/agent.h
+++ b/agent.h
@@ -20,8 +20,8 @@ cb_modspec *cb_agent_get_modspec_by_name(size_t name);
 size_t cb_agent_modspec_count(void);
 size_t cb_agent_add_struct_spec(struct cb_struct_spec spec);
 const struct cb_struct_spec *cb_agent_get_struct_spec(size_t id);
-FILE *cb_agent_resolve_import(const char *import_name, size_t len,
-		const char *pwd, char **fname_out);
+FILE *cb_agent_resolve_import(cb_str import_name, const char *pwd,
+		char **fname_out);
 
 #ifdef DEBUG_VM
 void cb_agent_set_finished_compiling();

--- a/bf.rbcvm
+++ b/bf.rbcvm
@@ -1,7 +1,7 @@
-import "lib/array.rbcvm";
-import "lib/arraylist.rbcvm";
-import "lib/iter.rbcvm";
-import "lib/string.rbcvm";
+import "array";
+import "arraylist";
+import "iter";
+import "string";
 
 struct Tape {
     pos,
@@ -11,54 +11,54 @@ struct Tape {
 function tape_new() {
     return Tape {
         pos = 0,
-        data = ArrayList.from_array(1, [0]),
+        data = arraylist.from_array(1, [0]),
     };
 }
 
 function tape_get(t) {
-    return ArrayList.get(t:data, t:pos);
+    return arraylist.get(t:data, t:pos);
 }
 
 function tape_inc(t, n) {
-    ArrayList.set(t:data, t:pos, ArrayList.get(t:data, t:pos) + n);
+    arraylist.set(t:data, t:pos, arraylist.get(t:data, t:pos) + n);
 }
 
 function tape_move(t, n) {
     t:pos = t:pos + n;
-    if (t:pos >= ArrayList.length(t:data)) {
-        ArrayList.push(t:data, 0);
+    if (t:pos >= arraylist.length(t:data)) {
+        arraylist.push(t:data, 0);
     }
 }
 
 struct Op { type, value }
 
 function parse(it) {
-    let ops = ArrayList.new();
+    let ops = arraylist.new();
     let c;
 
     while ((c = it())) {
         if (c == '+') {
-            ArrayList.push(ops, Op{type="inc", value=1});
+            arraylist.push(ops, Op{type="inc", value=1});
         } else if (c == '-') {
-            ArrayList.push(ops, Op{type="inc", value=-1});
+            arraylist.push(ops, Op{type="inc", value=-1});
         } else if (c == '>') {
-            ArrayList.push(ops, Op{type="move", value=1});
+            arraylist.push(ops, Op{type="move", value=1});
         } else if (c == '<') {
-            ArrayList.push(ops, Op{type="move", value=-1});
+            arraylist.push(ops, Op{type="move", value=-1});
         } else if (c == '.') {
-            ArrayList.push(ops, Op{type="print"});
+            arraylist.push(ops, Op{type="print"});
         } else if (c == '[') {
-            ArrayList.push(ops, Op{type="loop", value=parse(it)});
+            arraylist.push(ops, Op{type="loop", value=parse(it)});
         } else if (c == ']') {
             break;
         }
     }
 
-    return ArrayList.to_array(ops);
+    return arraylist.to_array(ops);
 }
 
 function run(ops, tape) {
-    let len = Array.length(ops);
+    let len = array.length(ops);
     for (let i = 0; i < len; i = i + 1) {
         let op = ops[i];
         let type = op:type;
@@ -77,9 +77,9 @@ function run(ops, tape) {
 }
 
 let args = argv();
-if (Array.length(args) != 3) {
+if (array.length(args) != 3) {
     println("Usage: ./cbcvm bf3.rbcvm <program>");
 } else {
-    let it = Iter.from_array(String.chars(read_file(args[2])));
+    let it = iter.from_array(string.chars(read_file(args[2])));
     run(parse(it), tape_new());
 }

--- a/bf.rbcvm
+++ b/bf.rbcvm
@@ -1,7 +1,7 @@
-import "array";
-import "arraylist";
-import "iter";
-import "string";
+import array;
+import arraylist;
+import iter;
+import string;
 
 struct Tape {
     pos,

--- a/cbcvm.c
+++ b/cbcvm.c
@@ -41,9 +41,10 @@ int main(int argc, char **argv) {
 	sigaction(SIGINT, &sigint_action, NULL);
 #endif
 
-	cb_agent_init();
+	if (cb_agent_init())
+		return 1;
 
-	int result = cb_compile_file(argv[1], &bytecode);
+	int result = cb_compile_file("<script>", argv[1], &bytecode);
 #ifdef DEBUG_DISASM
 	if (!result)
 		result = cb_disassemble(bytecode);

--- a/compiler.c
+++ b/compiler.c
@@ -70,7 +70,6 @@
 	X(TOK_LET) \
 	X(TOK_TRUE) \
 	X(TOK_FALSE) \
-	X(TOK_MODULE) \
 	X(TOK_EXPORT) \
 	X(TOK_IMPORT) \
 	X(TOK_STRUCT) \
@@ -128,7 +127,6 @@ static struct {
 	KW("null", TOK_NULL),
 	KW("true", TOK_TRUE),
 	KW("false", TOK_FALSE),
-	KW("module", TOK_MODULE),
 	KW("export", TOK_EXPORT),
 	KW("import", TOK_IMPORT),
 	KW("struct", TOK_STRUCT),
@@ -809,32 +807,6 @@ static struct token next(struct cstate *state, int *ok)
 /* Propagate errors */
 #define X(V) ({ if (V) return 1; })
 
-static int compile_module_header(struct cstate *state, int *already_compiled)
-{
-	struct token name;
-	size_t name_id;
-
-	*already_compiled = 0;
-	if (!MATCH_P(TOK_MODULE))
-		return 0;
-
-	EXPECT(TOK_MODULE);
-	name = EXPECT(TOK_IDENT);
-	EXPECT(TOK_SEMICOLON);
-
-	name_id = intern_ident(state, &name);
-	if ((state->modspec = cb_agent_get_modspec_by_name(name_id))) {
-		*already_compiled = 1;
-		return 0;
-	}
-	state->modspec = cb_modspec_new(name_id);
-
-	APPEND(OP_INIT_MODULE);
-	APPEND_SIZE_T(cb_modspec_id(state->modspec));
-
-	return 0;
-}
-
 static int compile_statement(struct cstate *);
 static int compile_let_statement(struct cstate *, size_t *name_out, int leave);
 static int compile_function_statement(struct cstate *, size_t *name_out,
@@ -853,38 +825,25 @@ static int compile_expression_statement(struct cstate *);
 
 static int compile_expression(struct cstate *);
 
-static int compile(struct cstate *state, int final, size_t *modname_out)
+static int compile(struct cstate *state, size_t name_id, int final)
 {
 	struct token *tok;
-	int already_compiled;
 
-	/* optional module header */
-	X(compile_module_header(state, &already_compiled));
+	state->modspec = cb_modspec_new(name_id);
 
-	if (modname_out) {
-		if (state->modspec)
-			*modname_out = cb_modspec_name(state->modspec);
-		else
-			*modname_out = -1;
-	}
-
-	if (already_compiled) {
-		state->modspec = NULL;
-		goto end;
-	}
+	APPEND(OP_INIT_MODULE);
+	APPEND_SIZE_T(cb_modspec_id(state->modspec));
 
 	while ((tok = PEEK()) && tok->type != TOK_EOF)
 		X(compile_statement(state));
 
 	EXPECT(TOK_EOF);
 
-	if (state->modspec) {
-		APPEND(OP_END_MODULE);
-		cb_agent_add_modspec(state->modspec);
-		state->modspec = NULL;
-	}
+	assert(state->modspec && "Missing modspec while compiling");
+	APPEND(OP_END_MODULE);
+	cb_agent_add_modspec(state->modspec);
+	state->modspec = NULL;
 
-end:
 	if (final) {
 		APPEND(OP_HALT);
 		bytecode_finalize(state->bytecode);
@@ -1343,10 +1302,7 @@ static int compile_export_statement(struct cstate *state)
 	size_t name;
 
 	tok = EXPECT(TOK_EXPORT);
-	if (!state->modspec) {
-		ERROR_AT(tok, "Cannot export from script (add a module header)");
-		return 1;
-	}
+	assert(state->modspec && "modspec not present while compiling");
 
 	if (!state->is_global) {
 		ERROR_AT(tok, "Can only export from global scope");
@@ -1360,7 +1316,7 @@ static int compile_export_statement(struct cstate *state)
 	} else if (MATCH_P(TOK_STRUCT)) {
 		X(compile_struct_statement(state, &name, 1));
 	} else {
-		ERROR_AT_P(PEEK(), "Can only export function and let declarations");
+		ERROR_AT_P(PEEK(), "Can only export function, let, and struct declarations");
 		return 1;
 	}
 
@@ -1370,16 +1326,17 @@ static int compile_export_statement(struct cstate *state)
 	return 0;
 }
 
-static int compile_file(struct cstate *state, const char *name, int final,
-		size_t *modname_out);
+static int compile_file(struct cstate *state, size_t name, const char *path,
+		FILE *f, int final);
 
 static int compile_import_statement(struct cstate *state)
 {
 	struct token tok, string;
-	char *filename;
+	char *filename, *modpath;
 	const char *modsrc;
 	size_t modname, modsrc_len;
 	const struct cb_builtin_module_spec *builtin;
+	FILE *f;
 
 	tok = EXPECT(TOK_IMPORT);
 	if (!state->is_global) {
@@ -1392,7 +1349,11 @@ static int compile_import_statement(struct cstate *state)
 
 	modsrc = tok_start(state, &string) + 1;
 	modsrc_len = tok_len(&string) - 2;
+	modname = cb_agent_intern_string(modsrc, modsrc_len);
 	builtin = NULL;
+
+	if (cb_hashmap_get(state->imported, modname))
+		return 0;
 
 	/* If the import name is one of the names is one of the builtin
 	 * modules, just add that builtin module to state->imported */
@@ -1403,7 +1364,6 @@ static int compile_import_statement(struct cstate *state)
 		if (!strncmp(cb_builtin_modules[i].name, modsrc,
 					builtin_name_len)) {
 			builtin = &cb_builtin_modules[i];
-			modname = cb_agent_intern_string(modsrc, modsrc_len);
 			break;
 		}
 	}
@@ -1413,37 +1373,39 @@ static int compile_import_statement(struct cstate *state)
 		if (strlen(state->filename) == sizeof("<script>") - 1
 				&& !strncmp("<script>", state->filename,
 					sizeof("<script>") - 1)) {
-			filename = malloc(modsrc_len + 1);
-			filename[tok_len(&string) - 1] = 0;
-			memcpy(filename, modsrc, modsrc_len);
+			filename = malloc(1);
+			*filename = 0;
 		} else {
 			char *real_path = realpath(state->filename, NULL);
 			const char *dir_name = dirname(real_path);
-			size_t len = strlen(dir_name) + modsrc_len + 1;
+			size_t len = strlen(dir_name);
 			filename = malloc(len + 1);
 			filename[len] = 0;
 			memcpy(filename, dir_name, strlen(dir_name));
-			filename[strlen(dir_name)] = '/';
-			memcpy(filename + strlen(dir_name) + 1, modsrc,
-					modsrc_len);
 			free(real_path);
 		}
 
-		if (state->modspec)
-			APPEND(OP_EXIT_MODULE);
-		X(compile_file(state, filename, 0, &modname));
-		if (state->modspec) {
-			APPEND(OP_ENTER_MODULE);
-			APPEND_SIZE_T(cb_modspec_id(state->modspec));
-		}
+		APPEND(OP_EXIT_MODULE);
+		f = cb_agent_resolve_import(modsrc, modsrc_len, filename,
+				&modpath);
 		free(filename);
+		if (!f)
+			goto error;
+		filename = strndup(modsrc, modsrc_len);
+		X(compile_file(state, modname, filename, f, 0));
+		free(filename);
+		assert(state->modspec && "Missing modspec while compiling");
+		APPEND(OP_ENTER_MODULE);
+		APPEND_SIZE_T(cb_modspec_id(state->modspec));
 	}
 
-	if (modname != -1)
-		cb_hashmap_set(state->imported, modname,
-				(struct cb_value) { .type = CB_VALUE_NULL });
+	cb_hashmap_set(state->imported, modname,
+			(struct cb_value) { .type = CB_VALUE_NULL });
 
 	return 0;
+
+error:
+	return 1;
 }
 
 static int compile_struct_decl(struct cstate *state, size_t *name_out)
@@ -2201,7 +2163,7 @@ int cb_compile(const char *input, struct bytecode **bc_out)
 	struct cstate state = cstate_default(1);
 	state.input = input;
 
-	result = compile(&state, 1, NULL);
+	result = compile(&state, cb_agent_intern_string("<string>", 8), 1);
 
 	cstate_free(state);
 	*bc_out = state.bytecode;
@@ -2209,10 +2171,9 @@ int cb_compile(const char *input, struct bytecode **bc_out)
 	return result;
 }
 
-static int read_file(const char *name, char **out)
+static int read_file(FILE *f, char **out)
 {
 	int result;
-	FILE *f;
 	size_t filesize;
 
 	assert(out != NULL);
@@ -2228,9 +2189,7 @@ static int read_file(const char *name, char **out)
 		} \
 	} while (0)
 
-	f = fopen(name, "rb");
 	/* FIXME: Return error code so caller can report */
-	HANDLE_ERROR(!f, fprintf(stderr, "File not found: '%s'\n", name));
 	HANDLE_ERROR(fseek(f, 0, SEEK_END), perror("fseek"));
 	filesize = ftell(f);
 	HANDLE_ERROR(fseek(f, 0, SEEK_SET), perror("fseek"));
@@ -2252,40 +2211,52 @@ epilogue:
 	return result;
 }
 
-static int compile_file(struct cstate *state, const char *name, int final,
-		size_t *modname_out)
+static int compile_file(struct cstate *state, size_t name, const char *path,
+		FILE *f, int final)
 {
 	int result;
 	char *input;
 	struct cstate new_state;
 
 	assert(state != NULL);
+	if (cb_agent_get_modspec_by_name(name))
+		return 0;
 
-	if (read_file(name, &input))
+	if (read_file(f, &input))
 		return 1;
 
 	new_state = cstate_default(0);
 	new_state.bytecode = state->bytecode;
 	new_state.input = input;
-	new_state.lex_state = lex_state_new(name);
-	new_state.filename = name;
+	new_state.lex_state = lex_state_new(path);
+	new_state.filename = path;
 
-	result = compile(&new_state, final, modname_out);
+	result = compile(&new_state, name, final);
 
 	free(input);
 	cstate_free(new_state);
 	return result;
 }
 
-int cb_compile_file(const char *name, struct bytecode **bc_out)
+int cb_compile_file(const char *name, const char *path,
+		struct bytecode **bc_out)
 {
 	int result;
-	struct cstate state = cstate_default(1);
+	FILE *f;
+	struct cstate state;
 
-	result = compile_file(&state, name, 1, NULL);
+	f = fopen(path, "rb");
+	if (!f) {
+		fprintf(stderr, "File not found: '%s'\n", path);
+		return 1;
+	}
+
+	state = cstate_default(1);
+	result = compile_file(&state,
+			cb_agent_intern_string(name, strlen(name)), path, f, 1);
+	*bc_out = state.bytecode;
 
 	cstate_free(state);
-	*bc_out = state.bytecode;
 
 	return result;
 }

--- a/compiler.h
+++ b/compiler.h
@@ -8,7 +8,7 @@ typedef struct bytecode cb_bytecode;
 typedef uint32_t cb_instruction;
 
 int cb_compile(const char *input, cb_bytecode **bc_out);
-int cb_compile_file(const char *name, cb_bytecode **bc_out);
+int cb_compile_file(const char *name, const char *path, cb_bytecode **bc_out);
 
 cb_instruction cb_bytecode_get(cb_bytecode *bc, size_t idx);
 size_t cb_bytecode_len(cb_bytecode *bc);

--- a/lib/array.rbcvm
+++ b/lib/array.rbcvm
@@ -1,5 +1,3 @@
-module Array;
-
 export let new = array_new;
 export let length = array_length;
 

--- a/lib/arraylist.rbcvm
+++ b/lib/arraylist.rbcvm
@@ -1,4 +1,4 @@
-import "array";
+import array;
 
 struct ArrayList {
   length,

--- a/lib/arraylist.rbcvm
+++ b/lib/arraylist.rbcvm
@@ -1,6 +1,4 @@
-module ArrayList;
-
-import "array.rbcvm";
+import "array";
 
 struct ArrayList {
   length,
@@ -14,7 +12,7 @@ export function from_array(len, array) {
 }
 
 export function with_capacity(cap) {
-  return from_array(0, Array.new(cap));
+  return from_array(0, array.new(cap));
 }
 
 export function new() {
@@ -26,7 +24,7 @@ export function length(self) {
 }
 
 export function capacity(self) {
-  return Array.length(self:array);
+  return array.length(self:array);
 }
 
 export function get(self, idx) {
@@ -46,7 +44,7 @@ export function delete(self, index) {
 }
 
 export function to_array(self) {
-  let new_array = Array.new(self:length);
+  let new_array = array.new(self:length);
 
   foreach(self, function(val, i) {
     new_array[i] = val;
@@ -58,10 +56,10 @@ export function to_array(self) {
 export function push(self, value) {
   let next_idx = self:length;
   let array = self:array;
-  let len = Array.length(array);
+  let len = array.length(array);
 
   if (next_idx >= len) {
-    let new_array = Array.new(2 * len);
+    let new_array = array.new(2 * len);
     for (let i = 0; i < next_idx; i = i + 1) {
       new_array[i] = array[i];
     }
@@ -106,7 +104,7 @@ export function find_index(self, func) {
 export function map(self, func) {
   let len = self:length;
   let cap = capacity(self);
-  let new_array = Array.new(cap);
+  let new_array = array.new(cap);
 
   foreach(self, function(val, i) {
     new_array[i] = val;

--- a/lib/assoclist.rbcvm
+++ b/lib/assoclist.rbcvm
@@ -1,12 +1,10 @@
-module AssocList;
+import "arraylist";
 
-import "arraylist.rbcvm";
-
-export let new = ArrayList.new;
-export let length = ArrayList.length;
+export let new = arraylist.new;
+export let length = arraylist.length;
 
 function get_entry(self, key) {
-  return ArrayList.find(self, function(entry) {
+  return arraylist.find(self, function(entry) {
     return entry[0] == key;
   });
 }
@@ -15,7 +13,7 @@ export function set(self, key, value) {
   let found = get_entry(self, key);
 
   if (found == null) {
-    ArrayList.push(self, [key, value]);
+    arraylist.push(self, [key, value]);
   } else {
     found[1] = value;
   }
@@ -32,27 +30,27 @@ export function get(self, key) {
 }
 
 export function delete(self, key) {
-  let idx = ArrayList.find_index(self, function(entry) {
+  let idx = arraylist.find_index(self, function(entry) {
     return entry[0] == key;
   });
 
   if (idx < 0) {
     return false;
   } else {
-    ArrayList.delete(self, idx);
+    arraylist.delete(self, idx);
   }
 }
 
 export function has(self, key) {
-  return null != ArrayList.find(self, function(entry) {
+  return null != arraylist.find(self, function(entry) {
     return entry[0] == key;
   });
 }
 
 export function is_empty(self) {
-  return ArrayList.length(self) == 0;
+  return arraylist.length(self) == 0;
 }
 
 export function entries(self) {
-  return ArrayList.to_array(self);
+  return arraylist.to_array(self);
 }

--- a/lib/assoclist.rbcvm
+++ b/lib/assoclist.rbcvm
@@ -1,4 +1,4 @@
-import "arraylist";
+import arraylist;
 
 export let new = arraylist.new;
 export let length = arraylist.length;

--- a/lib/box.rbcvm
+++ b/lib/box.rbcvm
@@ -1,5 +1,3 @@
-module Box;
-
 struct Box { inner }
 
 export function new(value) {

--- a/lib/char.rbcvm
+++ b/lib/char.rbcvm
@@ -1,5 +1,3 @@
-module Char;
-
 let ZERO = ord('0');
 let NINE = ord('9');
 

--- a/lib/fn.rbcvm
+++ b/lib/fn.rbcvm
@@ -1,4 +1,4 @@
-import "array";
+import array;
 
 export function identity(n) {
     return n;

--- a/lib/fn.rbcvm
+++ b/lib/fn.rbcvm
@@ -1,6 +1,4 @@
-module Fn;
-
-import "array.rbcvm";
+import "array";
 
 export function identity(n) {
     return n;
@@ -19,26 +17,26 @@ export function curry(fn, a) {
 }
 
 export function partial(fn, args) {
-    return Array.foldl(args, fn, function(acc, i) {
+    return array.foldl(args, fn, function(acc, i) {
         return curry(acc, i);
     });
 }
 
 export function compose(functions) {
-    return Array.foldl1(functions, function(acc, fn) {
+    return array.foldl1(functions, function(acc, fn) {
         return function(arg) {
             return acc(fn(arg));
         };
     });
 }
 
-export let chain = compose([compose, Array.reversed]);
+export let chain = compose([compose, array.reversed]);
 
 export function bind(fn, slf) {
     return function() {
         let args = arguments();
-        let args_len = Array.length(args);
-        let all_args = Array.new(args_len + 1);
+        let args_len = array.length(args);
+        let all_args = array.new(args_len + 1);
         all_args[0] = slf;
         for (let i = 0; i < args_len; i = i + 1) {
             all_args[i + 1] = args[i];

--- a/lib/hash.rbcvm
+++ b/lib/hash.rbcvm
@@ -1,15 +1,13 @@
-module Hash;
-
-import "array.rbcvm";
+import "array";
 
 let FNV_OFFSET_BASIS_32 = 2166136261;
 let FNV_PRIME_32 = 16777619;
 
 export function fnv1a(bytes) {
-  let len = Array.length(bytes);
+  let len = array.length(bytes);
   let hash = FNV_OFFSET_BASIS_32;
 
-  Array.foreach(bytes, function(byte) {
+  array.foreach(bytes, function(byte) {
     hash = hash ^ byte;
     hash = hash * FNV_PRIME_32;
   });

--- a/lib/hash.rbcvm
+++ b/lib/hash.rbcvm
@@ -1,4 +1,4 @@
-import "array";
+import array;
 
 let FNV_OFFSET_BASIS_32 = 2166136261;
 let FNV_PRIME_32 = 16777619;

--- a/lib/hashmap.rbcvm
+++ b/lib/hashmap.rbcvm
@@ -1,8 +1,8 @@
-import "array";
-import "arraylist";
-import "assoclist";
-import "hash";
-import "iter";
+import array;
+import arraylist;
+import assoclist;
+import hash;
+import iter;
 
 let INITIAL_CAPACITY = toint(2 ** 3);
 let LOAD_FACTOR = 0.7;

--- a/lib/hashmap.rbcvm
+++ b/lib/hashmap.rbcvm
@@ -1,11 +1,8 @@
-module HashMap;
-
-import "array.rbcvm";
-import "arraylist.rbcvm";
-import "assoclist.rbcvm";
-import "hash.rbcvm";
-import "iter.rbcvm";
-import "string.rbcvm";
+import "array";
+import "arraylist";
+import "assoclist";
+import "hash";
+import "iter";
 
 let INITIAL_CAPACITY = toint(2 ** 3);
 let LOAD_FACTOR = 0.7;
@@ -19,7 +16,7 @@ struct HashMap {
 # members
 
 function hash_string(str) {
-  return Hash.fnv1a(string_bytes(str));
+  return hash.fnv1a(string_bytes(str));
 }
 
 let default_hash = hash_string;
@@ -32,14 +29,14 @@ function grow(self) {
   let cap = self:cap = self:cap * 2;
 
   let old_buckets = self:buckets;
-  self:buckets = Array.new(cap);
+  self:buckets = array.new(cap);
   self:load = 0;
 
-  Array.foreach(old_buckets, function(bucket) {
+  array.foreach(old_buckets, function(bucket) {
     if (!bucket) {
       return;
     }
-    Array.foreach(AssocList.entries(bucket), function(entry) {
+    array.foreach(assoclist.entries(bucket), function(entry) {
       set(self, entry[0], entry[1]);
     });
   });
@@ -52,7 +49,7 @@ export function with_capacity(capacity) {
     cap=capacity,
     load=0,
     hash_fn=default_hash,
-    buckets=Array.new(capacity),
+    buckets=array.new(capacity),
   };
 }
 
@@ -78,7 +75,7 @@ export function get(self, key) {
     return null;
   }
 
-  return AssocList.get(bucket, key);
+  return assoclist.get(bucket, key);
 }
 
 export function set(self, key, value) {
@@ -86,12 +83,12 @@ export function set(self, key, value) {
   let bucket = self:buckets[hashed];
 
   if (bucket == null) {
-    bucket = AssocList.new();
+    bucket = assoclist.new();
     self:load = self:load + 1;
     self:buckets[hashed] = bucket;
   }
 
-  AssocList.set(bucket, key, value);
+  assoclist.set(bucket, key, value);
 
   if (self:load / self:cap > LOAD_FACTOR) {
     grow(self);
@@ -105,8 +102,8 @@ export function delete(self, key) {
     return false;
   }
 
-  if (AssocList.delete(bucket, key)) {
-    if (AssocList.is_empty(bucket)) {
+  if (assoclist.delete(bucket, key)) {
+    if (assoclist.is_empty(bucket)) {
       self:buckets[hashed] = null;
       self:load = self:load - 1;
     }
@@ -122,11 +119,11 @@ export function has(self, key) {
     return false;
   }
 
-  return AssocList.has(bucket, key);
+  return assoclist.has(bucket, key);
 }
 
 export function entries(self) {
-  let len = Array.length(self:buckets);
+  let len = array.length(self:buckets);
   let i = 0;
   let j = 0;
   let bucket = null;
@@ -135,8 +132,8 @@ export function entries(self) {
     if (i >= len) {
       return null;
     }
-    if (bucket && j < ArrayList.length(bucket)) {
-      let entry = ArrayList.get(bucket, j);
+    if (bucket && j < arraylist.length(bucket)) {
+      let entry = arraylist.get(bucket, j);
       j = j + 1;
       return entry;
     } else if (bucket) {
@@ -149,11 +146,11 @@ export function entries(self) {
 }
 
 export function keys(self) {
-  return Iter.map(entries(self), function (e) { return e[0]; });
+  return iter.map(entries(self), function (e) { return e[0]; });
 }
 
 export function values(self) {
-  return Iter.map(entries(self), function (e) { return e[1]; });
+  return iter.map(entries(self), function (e) { return e[1]; });
 }
 
 export function make_with_hash_function(hash, init_fn) {
@@ -183,7 +180,7 @@ export function from_entries(entries) {
 }
 
 export function extend(map, entries) {
-  Iter.foreach(entries, function(entry) {
+  iter.foreach(entries, function(entry) {
     set(map, entry[0], entry[1]);
   });
 }

--- a/lib/iter.rbcvm
+++ b/lib/iter.rbcvm
@@ -1,7 +1,5 @@
-module Iter;
-
-import "array.rbcvm";
-import "arraylist.rbcvm";
+import "array";
+import "arraylist";
 
 let idx = 0;
 
@@ -14,7 +12,7 @@ function ensure_iterable(it) {
 
 export function from_array(array) {
   let index = 0;
-  let len = Array.length(array);
+  let len = array.length(array);
   let i = idx;
   idx = idx + 1;
   return function from_array_iterator() {
@@ -72,13 +70,13 @@ export function foreach(_it, fn) {
 
 export function collect(_it) {
   let it = ensure_iterable(_it);
-  let dest = ArrayList.new();
+  let dest = arraylist.new();
 
   foreach(it, function(val) {
-    ArrayList.push(dest, val);
+    arraylist.push(dest, val);
   });
 
-  return ArrayList.to_array(dest);
+  return arraylist.to_array(dest);
 }
 
 export function map(_it, fn) {

--- a/lib/iter.rbcvm
+++ b/lib/iter.rbcvm
@@ -1,5 +1,5 @@
-import "array";
-import "arraylist";
+import array;
+import arraylist;
 
 let idx = 0;
 

--- a/lib/json.rbcvm
+++ b/lib/json.rbcvm
@@ -1,12 +1,9 @@
-module JSON;
-
-import "array.rbcvm";
-import "arraylist.rbcvm";
-import "char.rbcvm";
-import "hashmap.rbcvm";
-import "iter.rbcvm";
-import "result.rbcvm";
-import "string.rbcvm";
+import "array";
+import "arraylist";
+import "char";
+import "hashmap";
+import "result";
+import "string";
 
 
 let T_LEFT_BRACE = 0;
@@ -29,9 +26,9 @@ struct Token {
 }
 
 function tokenize(input) {
-  let chars = String.chars(input);
-  let tokens = ArrayList.new();
-  let len = Array.length(chars);
+  let chars = string.chars(input);
+  let tokens = arraylist.new();
+  let len = array.length(chars);
   let i = 0;
 
   while (i < len) {
@@ -92,7 +89,7 @@ function tokenize(input) {
 
       i = i + 1;
       token = Token{type=T_STRING, value=str};
-    } else if (Char.is_digit(char) || char == '-') {
+    } else if (char.is_digit(char) || char == '-') {
       let is_float = false;
       let c;
       let str;
@@ -108,11 +105,11 @@ function tokenize(input) {
         is_float = true;
         i = i + 1;
         str = string_concat(str, "0");
-      } else if (Char.is_digit(c) && c != '0') {
+      } else if (char.is_digit(c) && c != '0') {
         str = string_concat(str, tostring(c));
         i = i + 1;
       } else {
-        return Result.error(E_UNEXPECTED_TOKEN, c);
+        return result.error(E_UNEXPECTED_TOKEN, c);
       }
 
       if (chars[i] == '.') {
@@ -120,23 +117,23 @@ function tokenize(input) {
         i = i + 1;
         str = string_concat(str, ".");
       } else if (is_float) {
-        return Result.error(E_UNEXPECTED_TOKEN, chars[i]);
+        return result.error(E_UNEXPECTED_TOKEN, chars[i]);
       }
 
-      while (i < len && Char.is_digit(chars[i])) {
+      while (i < len && char.is_digit(chars[i])) {
         str = string_concat(str, tostring(chars[i]));
         i = i + 1;
       }
 
       token = Token{type=T_NUMBER, value=str};
     } else {
-      return Result.error(E_UNEXPECTED_TOKEN, char);
+      return result.error(E_UNEXPECTED_TOKEN, char);
     }
 
-    ArrayList.push(tokens, token);
+    arraylist.push(tokens, token);
   }
 
-  return Result.ok(ArrayList.to_array(tokens));
+  return result.ok(arraylist.to_array(tokens));
 }
 
 function parse_value(next, peek) {
@@ -146,7 +143,7 @@ function parse_value(next, peek) {
 
   let ret;
   if (type == T_NUMBER) {
-    ret = String.parse_float(value, 10);
+    ret = string.parse_float(value, 10);
   } else if (type == T_STRING) {
     ret = value;
   } else if (type == T_TRUE) {
@@ -156,14 +153,14 @@ function parse_value(next, peek) {
   } else if (type == T_NULL) {
     ret = null;
   } else if (type == T_LEFT_BRACE) {
-    let values = HashMap.new();
+    let values = hashmap.new();
     let is_first = true;
 
     while (peek():type != T_RIGHT_BRACE) {
       if (!is_first) {
         let comma = next();
         if (comma:type != T_COMMA) {
-          return Result.error(
+          return result.error(
             E_UNEXPECTED_TOKEN,
             string_concat("Expected comma, found '", comma:value, "'"),
           );
@@ -174,10 +171,10 @@ function parse_value(next, peek) {
 
       let key = parse_value(next, peek);
 
-      if (Result.is_ok(key)) {
-        key = Result.data(key);
-      } else if (type_of(Result.data(key)) != "string") {
-        return Result.error(
+      if (result.is_ok(key)) {
+        key = result.data(key);
+      } else if (type_of(result.data(key)) != "string") {
+        return result.error(
           E_UNEXPECTED_TOKEN,
           string_concat("Expected string, found ", key),
         );
@@ -187,7 +184,7 @@ function parse_value(next, peek) {
 
       let colon = next();
       if (colon:type != T_COLON) {
-        return Result.error(
+        return result.error(
           E_UNEXPECTED_TOKEN,
           string_concat("Expected colon, found '", comma:value, "'"),
         );
@@ -195,8 +192,8 @@ function parse_value(next, peek) {
 
       let map_value = parse_value(next, peek);
 
-      if (Result.is_ok(map_value)) {
-        HashMap.set(values, key, Result.data(map_value));
+      if (result.is_ok(map_value)) {
+        hashmap.set(values, key, result.data(map_value));
       } else {
         return map_value;
       }
@@ -206,14 +203,14 @@ function parse_value(next, peek) {
 
     ret = values;
   } else if (type == T_LEFT_BRACKET) {
-    let values = ArrayList.new();
+    let values = arraylist.new();
 
     let is_first = true;
     while (peek():type != T_RIGHT_BRACKET) {
       if (!is_first) {
         let comma = next();
         if (comma:type != T_COMMA) {
-          return Result.error(
+          return result.error(
             E_UNEXPECTED_TOKEN,
             string_concat("Expected comma, found '", comma:value, "'"),
           );
@@ -224,8 +221,8 @@ function parse_value(next, peek) {
 
       let result = parse_value(next, peek);
 
-      if (Result.is_ok(result)) {
-        ArrayList.push(values, Result.data(result));
+      if (result.is_ok(result)) {
+        arraylist.push(values, result.data(result));
       } else {
         return result;
       }
@@ -233,26 +230,26 @@ function parse_value(next, peek) {
 
     next(); # consume right bracket
 
-    ret = ArrayList.to_array(values);
+    ret = arraylist.to_array(values);
   } else {
-    return Result.error(
+    return result.error(
       E_UNEXPECTED_TOKEN,
       string_concat("Unexpected token ", tostring(value)),
     );
   }
 
-  return Result.ok(ret);
+  return result.ok(ret);
 }
 
 export function parse(input) {
   let tokens = tokenize(input);
   let i = 0;
 
-  if (Result.is_error(tokens)) {
+  if (result.is_error(tokens)) {
     return tokens;
   }
-  tokens = Result.data(tokens);
-  let len = Array.length(tokens);
+  tokens = result.data(tokens);
+  let len = array.length(tokens);
 
   function peek() {
     return tokens[i];
@@ -266,12 +263,12 @@ export function parse(input) {
 
   let data = parse_value(next, peek);
 
-  if (Result.is_error(data)) {
+  if (result.is_error(data)) {
     return data;
   }
 
   if (i != len) {
-    return Result.error(
+    return result.error(
       E_INVALID_JSON,
       string_concat("Expected EOF, found ", tostring(tokens[i - 1]:value)),
     );

--- a/lib/json.rbcvm
+++ b/lib/json.rbcvm
@@ -1,9 +1,9 @@
-import "array";
-import "arraylist";
-import "char";
-import "hashmap";
-import "result";
-import "string";
+import array;
+import arraylist;
+import char;
+import hashmap;
+import result;
+import string;
 
 
 let T_LEFT_BRACE = 0;

--- a/lib/list.rbcvm
+++ b/lib/list.rbcvm
@@ -1,5 +1,5 @@
-import "array";
-import "box";
+import array;
+import box;
 
 struct Node {
   car, cdr

--- a/lib/list.rbcvm
+++ b/lib/list.rbcvm
@@ -1,18 +1,16 @@
-module List;
-
-import "array.rbcvm";
-import "box.rbcvm";
+import "array";
+import "box";
 
 struct Node {
   car, cdr
 }
 
 export function new() {
-  return Box.new(null);
+  return box.new(null);
 }
 
 export function length(self) {
-  let current = Box.get(self);
+  let current = box.get(self);
   let len = 0;
 
   while (current) {
@@ -24,15 +22,15 @@ export function length(self) {
 }
 
 export function prepend(self, value) {
-  let current = Box.get(self);
-  Box.set(self, Node{car=value, cdr=current});
+  let current = box.get(self);
+  box.set(self, Node{car=value, cdr=current});
 }
 
 export function append(self, value) {
-  let current = Box.get(self);
+  let current = box.get(self);
   let prev = null;
   if (current == null) {
-    Box.set(self, Node{car=value, cdr=null});
+    box.set(self, Node{car=value, cdr=null});
     return;
   }
 
@@ -45,7 +43,7 @@ export function append(self, value) {
 }
 
 export function foreach(self, func) {
-  let current = Box.get(self);
+  let current = box.get(self);
 
   for (let i = 0; current; i = i + 1) {
     func(current:car, i, self);
@@ -54,7 +52,7 @@ export function foreach(self, func) {
 }
 
 export function find(self, func) {
-  let current = Box.get(self);
+  let current = box.get(self);
 
   for (let i = 0; current; i = i + 1) {
     if (func(current:car, i, self)) {
@@ -86,7 +84,7 @@ export function map(self, func) {
 }
 
 export function to_array(self) {
-  let arr = Array.new(length(self));
+  let arr = array.new(length(self));
 
   foreach(self, function(val, i) {
     arr[i] = val;

--- a/lib/math.rbcvm
+++ b/lib/math.rbcvm
@@ -1,5 +1,3 @@
-module Math;
-
 export function abs(n) {
     if (n < 0) {
         return -n;

--- a/lib/obj.rbcvm
+++ b/lib/obj.rbcvm
@@ -1,7 +1,3 @@
-module Obj;
-
-import "fn.rbcvm";
-import "op.rbcvm";
 import "result.rbcvm";
 
 export let E_NO_SUCH_METHOD = -1;
@@ -40,7 +36,7 @@ export function _send(cls, obj, msg, args) {
   if (meth == null) {
     meth = resolve_method(cls, "method_missing");
     if (meth == null) {
-        return Result.error(E_NO_SUCH_METHOD, msg);
+        return result.error(E_NO_SUCH_METHOD, msg);
     }
     let args_len = Array.length(args);
     let new_args = Array.new(args_len + 2);

--- a/lib/obj.rbcvm
+++ b/lib/obj.rbcvm
@@ -1,4 +1,4 @@
-import "result.rbcvm";
+import result;
 
 export let E_NO_SUCH_METHOD = -1;
 

--- a/lib/op.rbcvm
+++ b/lib/op.rbcvm
@@ -1,5 +1,3 @@
-module Op;
-
 export function eq(a, b) {
   return a == b;
 }

--- a/lib/result.rbcvm
+++ b/lib/result.rbcvm
@@ -1,5 +1,3 @@
-module Result;
-
 export let OK = "ok";
 export let ERROR = "error";
 

--- a/lib/string.rbcvm
+++ b/lib/string.rbcvm
@@ -1,10 +1,8 @@
-module String;
-
-import "array.rbcvm";
-import "char.rbcvm";
-import "fn.rbcvm";
-import "iter.rbcvm";
-import "op.rbcvm";
+import "array";
+import "char";
+import "fn";
+import "iter";
+import "op";
 
 export let chars = string_chars;
 export let from_chars = string_from_chars;
@@ -13,11 +11,11 @@ export let bytes = string_bytes;
 export function parse_integer(str, base) {
   let sum = 0;
   let cs = chars(str);
-  Array.reverse(cs);
+  array.reverse(cs);
 
-  Array.foreach(cs, function(char, i) {
-    if (Char.is_digit(char)) {
-      sum = sum + toint(Char.to_digit(char) * base ** i);
+  array.foreach(cs, function(char, i) {
+    if (char.is_digit(char)) {
+      sum = sum + toint(char.to_digit(char) * base ** i);
     }
   });
 
@@ -33,18 +31,18 @@ export function parse_float(str) {
     negate = true;
   }
 
-  chars = Iter.from_array(chars);
+  chars = iter.from_array(chars);
   if (negate) {
-    chars = Iter.drop(chars, 1);
+    chars = iter.drop(chars, 1);
   }
 
-  let integer_chars = Iter.collect(Iter.take_while(chars, Fn.curry(Op.ne, '.')));
+  let integer_chars = iter.collect(iter.take_while(chars, fn.curry(op.ne, '.')));
   sum = sum + parse_integer(from_chars(integer_chars), 10);
 
-  Iter.foreach(Iter.enumerate(chars), function(ic) {
+  iter.foreach(iter.enumerate(chars), function(ic) {
     let i = ic[0];
     let c = ic[1];
-    sum = sum + tofloat(Char.to_digit(c)) / 10 ** (i + 1);
+    sum = sum + tofloat(char.to_digit(c)) / 10 ** (i + 1);
   });
 
   if (negate) {
@@ -56,5 +54,5 @@ export function parse_float(str) {
 
 export function slice(self, start, end) {
     let cs = chars(self);
-    return from_chars(Array.slice(cs, start, end));
+    return from_chars(array.slice(cs, start, end));
 }

--- a/lib/string.rbcvm
+++ b/lib/string.rbcvm
@@ -1,8 +1,8 @@
-import "array";
-import "char";
-import "fn";
-import "iter";
-import "op";
+import array;
+import char;
+import fn;
+import iter;
+import op;
 
 export let chars = string_chars;
 export let from_chars = string_from_chars;

--- a/test.rbcvm
+++ b/test.rbcvm
@@ -1,10 +1,10 @@
-import "lib/array.rbcvm";
-import "lib/arraylist.rbcvm";
-import "lib/hash.rbcvm";
-import "lib/hashmap.rbcvm";
-import "lib/iter.rbcvm";
-import "lib/result.rbcvm";
-import "lib/string.rbcvm";
+import array;
+import arraylist;
+import hash;
+import hashmap;
+import iter;
+import result;
+import string;
 
 (function main() {
     function tape_new() {


### PR DESCRIPTION
See 7e46deb

This does not support importing from directories within a directory in CBCVM_PATH, like `lib/inner/abc.rbcvm`, where `lib` is in CBCVM_PATH.

Some next steps could be to support that, and in the process change it to be more like Python, i.e. using identifier tokens for imports, and dot-separated paths for module hierarchies.