### PR TITLE
Struct spec gc

### DIFF
--- a/agent.c
+++ b/agent.c
@@ -8,7 +8,6 @@
 #include "builtin_modules.h"
 #include "module.h"
 #include "str.h"
-#include "struct.h"
 
 #define INITIAL_STRING_TABLE_SIZE 4
 #define MAX_IMPORT_PATHS 256
@@ -27,13 +26,6 @@ struct cb_agent {
 
 	char *cbcvm_path;
 	const char *import_paths[MAX_IMPORT_PATHS];
-
-	struct cb_struct_spec *struct_specs;
-	size_t struct_specs_len;
-
-#ifdef DEBUG_VM
-	int finished_compiling;
-#endif
 };
 
 static struct cb_agent agent;
@@ -52,12 +44,6 @@ int cb_agent_init(void)
 	agent.next_string_id = 0;
 	agent.string_table_size = 0;
 	agent.modules_size = 0;
-	agent.struct_specs = NULL;
-	agent.struct_specs_len = 0;
-
-#ifdef DEBUG_VM
-	agent.finished_compiling = 0;
-#endif
 
 	for (i = 0; i < MAX_IMPORT_PATHS; i += 1)
 		agent.import_paths[i] = NULL;
@@ -102,13 +88,9 @@ void cb_agent_deinit(void)
 		}
 		free(agent.modules);
 	}
-	if (agent.struct_specs)
-		free(agent.struct_specs);
 
 	agent.string_table = NULL;
 	agent.modules = NULL;
-	agent.struct_specs = NULL;
-	agent.struct_specs_len = 0;
 
 	if (agent.cbcvm_path) {
 		free(agent.cbcvm_path);
@@ -208,37 +190,6 @@ inline size_t cb_agent_modspec_count(void)
 {
 	return agent.next_module_id;
 }
-
-size_t cb_agent_add_struct_spec(struct cb_struct_spec struct_spec)
-{
-#ifdef DEBUG_VM
-	assert(!agent.finished_compiling
-			&& "Cannot add struct spec after compiling");
-#endif
-	agent.struct_specs_len += 1;
-	agent.struct_specs = realloc(agent.struct_specs,
-			sizeof(struct cb_struct_spec)
-			* agent.struct_specs_len);
-	agent.struct_specs[agent.struct_specs_len - 1] = struct_spec;
-	return agent.struct_specs_len - 1;
-}
-
-const struct cb_struct_spec *cb_agent_get_struct_spec(size_t id)
-{
-#ifdef DEBUG_VM
-	assert(agent.finished_compiling
-			&& "Cannot get struct spec while compiling");
-#endif
-	assert(id >= 0 && id < agent.struct_specs_len);
-	return &agent.struct_specs[id];
-}
-
-#ifdef DEBUG_VM
-void cb_agent_set_finished_compiling()
-{
-	agent.finished_compiling = 1;
-}
-#endif
 
 /* Given a name like "hashmap", find a matching file relative to one of the
    paths in CBCVM_PATH with a .rbcvm extension. If found, it will be opened and

--- a/agent.h
+++ b/agent.h
@@ -18,13 +18,7 @@ size_t cb_agent_reserve_modspec_id();
 const cb_modspec *cb_agent_get_modspec(size_t id);
 cb_modspec *cb_agent_get_modspec_by_name(size_t name);
 size_t cb_agent_modspec_count(void);
-size_t cb_agent_add_struct_spec(struct cb_struct_spec spec);
-const struct cb_struct_spec *cb_agent_get_struct_spec(size_t id);
 FILE *cb_agent_resolve_import(cb_str import_name, const char *pwd,
 		char **fname_out);
-
-#ifdef DEBUG_VM
-void cb_agent_set_finished_compiling();
-#endif
 
 #endif

--- a/builtin_modules.c
+++ b/builtin_modules.c
@@ -8,9 +8,11 @@
 #include "module.h"
 
 #include "modules/time.h"
+#include "modules/structs.h"
 
 static const struct cb_builtin_module_spec builtins[] = {
 	{"time", cb_time_build_spec, cb_time_instantiate},
+	{"structs", cb_structs_build_spec, cb_structs_instantiate},
 };
 const struct cb_builtin_module_spec *cb_builtin_modules = builtins;
 const size_t cb_builtin_module_count = sizeof(builtins) / sizeof(builtins[0]);

--- a/compiler.c
+++ b/compiler.c
@@ -1358,7 +1358,7 @@ static int compile_import_statement(struct cstate *state)
 	 * modules, just add that builtin module to state->imported */
 	for (size_t i = 0; i < cb_builtin_module_count; i += 1) {
 		size_t builtin_name_len = strlen(cb_builtin_modules[i].name);
-		if (!cb_str_eq_cstr(modsrc, cb_builtin_modules[i].name,
+		if (cb_str_eq_cstr(modsrc, cb_builtin_modules[i].name,
 				builtin_name_len)) {
 			builtin = &cb_builtin_modules[i];
 			break;

--- a/disassemble.c
+++ b/disassemble.c
@@ -103,7 +103,6 @@ int cb_disassemble_one(cb_bytecode *bytecode, size_t pc)
 	case OP_ENTER_MODULE:
 	case OP_NEW_ARRAY_WITH_VALUES:
 	case OP_CALL:
-	case OP_NEW_STRUCT_SPEC:
 		printf("%s(%zu)\n", cb_opcode_name(op), NEXT_USIZE());
 		return WITH_ARGS(1);
 
@@ -138,6 +137,21 @@ int cb_disassemble_one(cb_bytecode *bytecode, size_t pc)
 		printf("%s(%zu, %zu)\n", cb_opcode_name(op), arg1,
 				arg2);
 		return WITH_ARGS(2);
+	}
+
+	case OP_NEW_STRUCT_SPEC: {
+		size_t name_id, nfields, field_name, i;
+		name_id = NEXT_USIZE();
+		nfields = NEXT_USIZE();
+		printf("%s(\"%s\"", cb_opcode_name(op),
+				cb_strptr(cb_agent_get_string(name_id)));
+		for (i = 0; i < nfields; i += 1) {
+			field_name = NEXT_USIZE();
+			printf(", \"%s\"", cb_strptr(
+					cb_agent_get_string(field_name)));
+		}
+		puts(")");
+		return WITH_ARGS(nfields + 2);
 	}
 
 	default:

--- a/eval.c
+++ b/eval.c
@@ -985,12 +985,17 @@ DO_OP_NEW_STRUCT: {
 }
 
 DO_OP_NEW_STRUCT_SPEC: {
-	size_t struct_id;
+	size_t name_id, nfields;
 	struct cb_value val;
-	struct_id = READ_SIZE_T();
+	name_id = READ_SIZE_T();
+	nfields = READ_SIZE_T();
 	val.type = CB_VALUE_STRUCT_SPEC;
-	val.val.as_struct_spec = cb_agent_get_struct_spec(struct_id);
-	assert(val.val.as_struct_spec);
+	val.val.as_struct_spec = cb_struct_spec_new(name_id, nfields);
+	for (size_t i = 0; i < nfields; i += 1) {
+		size_t field_id = READ_SIZE_T();
+		cb_struct_spec_set_field_name(val.val.as_struct_spec, i,
+				field_id);
+	}
 	PUSH(val);
 	DISPATCH();
 }

--- a/intrinsics.h
+++ b/intrinsics.h
@@ -1,7 +1,34 @@
 #ifndef cb_intrinsics_h
 #define cb_intrinsics_h
 
+#include <stdio.h>
+
+#include "agent.h"
 #include "hashmap.h"
+#include "value.h"
+
+#define CB_EXPECT_TYPE(TYPE, VAL) ({ \
+		if ((VAL).type != (TYPE)) { \
+			fprintf(stderr, "%s: expected %s argument, got %s\n", \
+					__func__, \
+					cb_value_type_friendly_name(TYPE), \
+					cb_value_type_of(&(VAL))); \
+			return 1; \
+		} \
+	})
+#define CB_EXPECT_STRING(VAL) ({ \
+		cb_str _CB_EXPECT_STRING_str; \
+		if ((VAL).type == CB_VALUE_STRING) { \
+			_CB_EXPECT_STRING_str = (VAL).val.as_string->string; \
+		} else if ((VAL).type == CB_VALUE_INTERNED_STRING) { \
+			_CB_EXPECT_STRING_str = cb_agent_get_string( \
+					(VAL).val.as_interned_string); \
+		} else { \
+			CB_EXPECT_TYPE(CB_VALUE_STRING, (VAL)); \
+			return 1; \
+		} \
+		_CB_EXPECT_STRING_str; \
+	})
 
 void make_intrinsics(cb_hashmap *scope);
 void cb_intrinsics_set_argv(int argc, char **argv);

--- a/modules/structs.c
+++ b/modules/structs.c
@@ -1,0 +1,155 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "agent.h"
+#include "intrinsics.h"
+#include "module.h"
+#include "str.h"
+#include "struct.h"
+#include "value.h"
+
+static size_t ident_new, ident_fields, ident_spec,
+		ident_name, ident_get, ident_set;
+
+#define DEFINE_EXPORT(SPEC, NAME, VAR) \
+	cb_modspec_add_export((SPEC), \
+		((VAR) = cb_agent_intern_string((NAME), sizeof((NAME)) - 1)))
+#define SET_EXPORT(MOD, NAME, VAL) \
+	cb_hashmap_set((MOD)->global_scope, (NAME), (VAL));
+
+void cb_structs_build_spec(cb_modspec *spec)
+{
+	DEFINE_EXPORT(spec, "new", ident_new);
+	DEFINE_EXPORT(spec, "fields", ident_fields);
+	DEFINE_EXPORT(spec, "spec", ident_spec);
+	DEFINE_EXPORT(spec, "name", ident_name);
+	DEFINE_EXPORT(spec, "get", ident_get);
+	DEFINE_EXPORT(spec, "set", ident_set);
+}
+
+static int make_struct_spec(size_t argc, struct cb_value *argv,
+		struct cb_value *result)
+{
+	cb_str name;
+	size_t i;
+
+	name = CB_EXPECT_STRING(argv[0]);
+
+	result->type = CB_VALUE_STRUCT_SPEC;
+	result->val.as_struct_spec = cb_struct_spec_new(
+			cb_agent_intern_string(cb_strptr(name), cb_strlen(name)),
+			argc - 1);
+
+	for (i = 1; i < argc; i += 1) {
+		name = CB_EXPECT_STRING(argv[i]);
+		cb_struct_spec_set_field_name(result->val.as_struct_spec, i - 1,
+				cb_agent_intern_string(cb_strptr(name),
+					cb_strlen(name)));
+	}
+
+	return 0;
+}
+
+static int get_spec_fields(size_t argc, struct cb_value *argv,
+		struct cb_value *result)
+{
+	struct cb_struct_spec *spec;
+	struct cb_value *el;
+	size_t i;
+
+	CB_EXPECT_TYPE(CB_VALUE_STRUCT_SPEC, argv[0]);
+
+	spec = argv[0].val.as_struct_spec;
+	result->type = CB_VALUE_ARRAY;
+	result->val.as_array = cb_array_new(spec->nfields);
+	result->val.as_array->len = spec->nfields;
+
+	for (i = 0; i < spec->nfields; i += 1) {
+		el = &result->val.as_array->values[i];
+		el->type = CB_VALUE_INTERNED_STRING;
+		el->val.as_interned_string = spec->fields[i];
+	}
+
+	return 0;
+}
+
+static int get_struct_spec(size_t argc, struct cb_value *argv,
+		struct cb_value *result)
+{
+	CB_EXPECT_TYPE(CB_VALUE_STRUCT, argv[0]);
+	result->type = CB_VALUE_STRUCT_SPEC;
+	result->val.as_struct_spec = argv[0].val.as_struct->spec;
+	return 0;
+}
+
+static int get_spec_name(size_t argc, struct cb_value *argv,
+		struct cb_value *result)
+{
+	CB_EXPECT_TYPE(CB_VALUE_STRUCT_SPEC, argv[0]);
+	result->type = CB_VALUE_INTERNED_STRING;
+	result->val.as_interned_string = argv[0].val.as_struct_spec->name;
+	return 0;
+}
+
+static int get_struct_field(size_t argc, struct cb_value *argv,
+		struct cb_value *result)
+{
+	cb_str fname;
+	struct cb_value *fvalue;
+	char *as_str;
+
+	CB_EXPECT_TYPE(CB_VALUE_STRUCT, argv[0]);
+	fname = CB_EXPECT_STRING(argv[1]);
+	fvalue = cb_struct_get_field(argv[0].val.as_struct,
+			cb_agent_intern_string(cb_strptr(fname),
+				cb_strlen(fname)));
+	if (fvalue == NULL) {
+		fprintf(stderr, "Value '%s' has no field '%s'\n",
+				(as_str = cb_value_to_string(&argv[0])),
+				cb_strptr(fname));
+		free(as_str);
+		return 1;
+	}
+
+	*result = *fvalue;
+	return 0;
+}
+
+static int set_struct_field(size_t argc, struct cb_value *argv,
+		struct cb_value *result)
+{
+	cb_str fname;
+	char *as_str;
+	size_t fname_id;
+	int retval;
+
+	CB_EXPECT_TYPE(CB_VALUE_STRUCT, argv[0]);
+	fname = CB_EXPECT_STRING(argv[1]);
+	fname_id = cb_agent_intern_string(cb_strptr(fname), cb_strlen(fname));
+	retval = cb_struct_set_field(argv[0].val.as_struct, fname_id, argv[2]);
+	if (retval) {
+		fprintf(stderr, "Value '%s' has no field '%s'\n",
+				(as_str = cb_value_to_string(&argv[0])),
+				cb_strptr(fname));
+		free(as_str);
+		return 1;
+	}
+
+	result->type = CB_VALUE_NULL;
+	return 0;
+}
+
+void cb_structs_instantiate(struct cb_module *mod)
+{
+	SET_EXPORT(mod, ident_new, cb_cfunc_new(ident_new, 1, make_struct_spec));
+	SET_EXPORT(mod, ident_fields,
+			cb_cfunc_new(ident_fields, 1, get_spec_fields));
+	SET_EXPORT(mod, ident_spec,
+			cb_cfunc_new(ident_spec, 1, get_struct_spec));
+	SET_EXPORT(mod, ident_name,
+			cb_cfunc_new(ident_name, 1, get_spec_name));
+	SET_EXPORT(mod, ident_get,
+			cb_cfunc_new(ident_get, 2, get_struct_field));
+	SET_EXPORT(mod, ident_set,
+			cb_cfunc_new(ident_set, 3, set_struct_field));
+}

--- a/modules/structs.h
+++ b/modules/structs.h
@@ -1,0 +1,9 @@
+#ifndef cb_modules_structs_h
+#define cb_modules_structs_h
+
+#include "module.h"
+
+void cb_structs_build_spec(cb_modspec *spec);
+void cb_structs_instantiate(struct cb_module *mod);
+
+#endif

--- a/modules/time.h
+++ b/modules/time.h
@@ -1,6 +1,8 @@
 #ifndef cb_modules_time_h
 #define cb_modules_time_h
 
+#include "module.h"
+
 void cb_time_build_spec(cb_modspec *spec);
 void cb_time_instantiate(struct cb_module *mod);
 

--- a/struct.c
+++ b/struct.c
@@ -6,22 +6,25 @@
 #include "struct.h"
 #include "value.h"
 
-void cb_struct_spec_init(struct cb_struct_spec *spec, size_t name)
+struct cb_struct_spec *cb_struct_spec_new(size_t name, size_t nfields)
 {
+	struct cb_struct_spec *spec;
+
+	spec = cb_malloc(sizeof(struct cb_struct_spec)
+			+ sizeof(size_t) * nfields, NULL);
 	spec->name = name;
-	spec->nfields = 0;
-	spec->fields = NULL;
+	spec->nfields = nfields;
+
+	return spec;
 }
 
-size_t cb_struct_spec_add_field(struct cb_struct_spec *spec, size_t field)
+void cb_struct_spec_set_field_name(struct cb_struct_spec *spec, size_t i,
+		size_t name)
 {
-	spec->nfields += 1;
-	spec->fields = realloc(spec->fields, spec->nfields * sizeof(size_t));
-	spec->fields[spec->nfields - 1] = field;
-	return spec->nfields - 1;
+	spec->fields[i] = name;
 }
 
-struct cb_struct *cb_struct_spec_instantiate(const struct cb_struct_spec *spec)
+struct cb_struct *cb_struct_spec_instantiate(struct cb_struct_spec *spec)
 {
 	struct cb_struct *val;
 	size_t i;

--- a/struct.h
+++ b/struct.h
@@ -8,22 +8,23 @@
 #include "value.h"
 
 struct cb_struct_spec {
+	cb_gc_header gc_header;
 	size_t name;
 	/* A list of interned strings. The index of the string is the index of
 	   the corresponding field. */
-	size_t *fields, nfields;
+	size_t nfields, fields[];
 };
 
 struct cb_struct {
 	cb_gc_header gc_header;
-	const struct cb_struct_spec *spec;
+	struct cb_struct_spec *spec;
 	struct cb_value fields[];
 };
 
-void cb_struct_spec_init(struct cb_struct_spec *spec, size_t name);
-size_t cb_struct_spec_add_field(struct cb_struct_spec *spec, size_t field);
-struct cb_struct *cb_struct_spec_instantiate(
-		const struct cb_struct_spec *spec);
+struct cb_struct_spec *cb_struct_spec_new(size_t name, size_t nfields);
+void cb_struct_spec_set_field_name(struct cb_struct_spec *spec, size_t i,
+		size_t name);
+struct cb_struct *cb_struct_spec_instantiate(struct cb_struct_spec *spec);
 struct cb_value *cb_struct_get_field(struct cb_struct *s, size_t name);
 int cb_struct_set_field(struct cb_struct *s, size_t name, struct cb_value val);
 

--- a/value.h
+++ b/value.h
@@ -79,9 +79,7 @@ struct cb_value {
 		struct cb_array *as_array;
 		struct cb_function *as_function;
 		struct cb_struct *as_struct;
-		/* the struct spec is not garbage collected; it needs to have a
-		   lifetime as long as the VM */
-		const struct cb_struct_spec *as_struct_spec;
+		struct cb_struct_spec *as_struct_spec;
 		struct cb_userdata *as_userdata;
 	} val;
 };


### PR DESCRIPTION
Closes #16

This change allows for dynamic generation of struct specs. Implementing that gave me the idea of adding general introspection functions so I did. This is now possible:

```js
import structs;

let spec = structs.new("Test", "a", "b", "c");
let s = spec { a = 1, b = 2, c = 3 };
println(structs.fields(structs.spec(s)));
println(structs.name(structs.spec(s)));

println(structs.get(s, "a"));
structs.set(s, "b", 12);
println(s:b);
```

The only problem with this is that every string passed to any of those functions gets interned. In that example it's fine since they were all interned anyway (because they are literals), truly dynamic struct generation could result in a very large string table (and those strings will never be freed).