### PR TITLE
Pre-allocate stack at function call entry

### DIFF
--- a/error.c
+++ b/error.c
@@ -65,7 +65,7 @@ void cb_traceback_add_frame(struct cb_frame *frame)
 
 	tb = malloc(sizeof(struct cb_traceback));
 	tb->frame = *frame;
-	if (frame->is_function)
+	if (CB_VALUE_IS_USER_FN(&frame->func))
 		tb->func = cb_vm_state.stack[frame->bp];
 	tb->next = cb_vm_state.error->tb;
 	cb_vm_state.error->tb = tb;
@@ -77,7 +77,7 @@ void cb_traceback_print(FILE *f, struct cb_traceback *tb)
 	struct cb_user_function *ufunc;
 	const cb_modspec *spec;
 
-	if (tb->frame.is_function) {
+	if (CB_VALUE_IS_USER_FN(&tb->frame.func)) {
 		cb_str buf;
 
 		func = tb->func.val.as_function;
@@ -120,7 +120,7 @@ void cb_error_mark(void)
 
 	cb_value_mark(&e->value);
 	for (tb = e->tb; tb; tb = tb->next) {
-		if (tb->frame.is_function)
+		if (CB_VALUE_IS_USER_FN(&tb->frame.func))
 			cb_value_mark(&tb->func);
 	}
 }

--- a/eval.h
+++ b/eval.h
@@ -21,7 +21,7 @@ struct cb_frame {
 	struct cb_frame *parent;
 	size_t bp;
 	struct cb_module *module;
-	int is_function;
+	struct cb_value func;
 };
 
 union cb_inline_cache {

--- a/gc.c
+++ b/gc.c
@@ -103,6 +103,7 @@ static void mark(void)
 	 * - stack
 	 * - globals
 	 * - vm state error
+	 * - functions in frames
 	 */
 
 	DEBUG_LOG("marking stack values");
@@ -125,6 +126,12 @@ static void mark(void)
 
 	DEBUG_LOG("marking error");
 	cb_error_mark();
+
+	DEBUG_LOG("marking frame functions");
+	for (struct cb_frame *f = cb_vm_state.frame; f; f = f->parent) {
+		if (CB_VALUE_IS_USER_FN(&f->func))
+			cb_value_mark(&f->func);
+	}
 
 	evaluate_mark_queue();
 }

--- a/modules/module.c
+++ b/modules/module.c
@@ -130,7 +130,7 @@ static int import(size_t argc, struct cb_value *argv, struct cb_value *result)
 	/* Make room in cb_vm_state for new module */
 	cb_vm_grow_modules_array(cb_agent_modspec_count());
 
-	frame.is_function = 0;
+	frame.func.type = CB_VALUE_NULL;
 	frame.module = NULL;
 	frame.parent = cb_vm_state.frame;
 	frame.bp = cb_vm_state.stack_top - cb_vm_state.stack;

--- a/opcode.c
+++ b/opcode.c
@@ -1,3 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "compiler.h"
 #include "opcode.h"
 
 const char *cb_opcode_name(enum cb_opcode op)
@@ -9,4 +13,166 @@ const char *cb_opcode_name(enum cb_opcode op)
 		return "";
 	}
 #undef CASE
+}
+
+int cb_opcode_stack_effect(enum cb_opcode op, cb_instruction *args)
+{
+	switch (op) {
+	case OP_HALT:
+	case OP_JUMP:
+	case OP_STORE_LOCAL:
+	case OP_DECLARE_GLOBAL:
+	case OP_STORE_GLOBAL:
+	case OP_BIND_LOCAL:
+	case OP_BIND_UPVALUE:
+	case OP_STORE_UPVALUE:
+	case OP_BITWISE_NOT:
+	case OP_NOT:
+	case OP_NEG:
+	case OP_INIT_MODULE:
+	case OP_END_MODULE:
+	case OP_ENTER_MODULE:
+	case OP_EXIT_MODULE:
+	case OP_NEW_STRUCT:
+	case OP_LOAD_STRUCT:
+	case OP_ROT_2:
+	case OP_MAX:
+		return 0;
+	case OP_CONST_INT:
+	case OP_CONST_DOUBLE:
+	case OP_CONST_STRING:
+	case OP_CONST_CHAR:
+	case OP_CONST_TRUE:
+	case OP_CONST_FALSE:
+	case OP_CONST_NULL:
+	case OP_LOAD_LOCAL:
+	case OP_LOAD_GLOBAL:
+	case OP_NEW_FUNCTION:
+	case OP_LOAD_UPVALUE:
+	case OP_LOAD_FROM_MODULE:
+	case OP_DUP:
+	case OP_NEW_STRUCT_SPEC:
+		return 1;
+	case OP_CALL:
+		return -args[0];
+	case OP_NEW_ARRAY_WITH_VALUES:
+		return 1 - args[0];
+	case OP_ADD:
+	case OP_SUB:
+	case OP_MUL:
+	case OP_DIV:
+	case OP_MOD:
+	case OP_EXP:
+	case OP_JUMP_IF_TRUE:
+	case OP_JUMP_IF_FALSE:
+	case OP_RETURN:
+	case OP_POP:
+	case OP_ARRAY_GET:
+	case OP_EQUAL:
+	case OP_NOT_EQUAL:
+	case OP_LESS_THAN:
+	case OP_LESS_THAN_EQUAL:
+	case OP_GREATER_THAN:
+	case OP_GREATER_THAN_EQUAL:
+	case OP_BITWISE_AND:
+	case OP_BITWISE_OR:
+	case OP_BITWISE_XOR:
+	case OP_STORE_STRUCT:
+	case OP_ADD_STRUCT_FIELD:
+		return -1;
+	case OP_ARRAY_SET:
+		return -2;
+	default:
+		fprintf(stderr, "Unknown opcode: %d\n", op);
+		abort();
+	}
+}
+
+unsigned cb_opcode_nargs(enum cb_opcode op, cb_instruction *args)
+{
+	switch (op) {
+	case OP_MAX:
+	case OP_HALT:
+	case OP_CONST_TRUE:
+	case OP_CONST_FALSE:
+	case OP_CONST_NULL:
+	case OP_ADD:
+	case OP_SUB:
+	case OP_MUL:
+	case OP_DIV:
+	case OP_MOD:
+	case OP_EXP:
+	case OP_POP:
+	case OP_ARRAY_GET:
+	case OP_ARRAY_SET:
+	case OP_EQUAL:
+	case OP_NOT_EQUAL:
+	case OP_LESS_THAN:
+	case OP_LESS_THAN_EQUAL:
+	case OP_GREATER_THAN:
+	case OP_GREATER_THAN_EQUAL:
+	case OP_BITWISE_OR:
+	case OP_BITWISE_AND:
+	case OP_BITWISE_XOR:
+	case OP_BITWISE_NOT:
+	case OP_NOT:
+	case OP_NEG:
+	case OP_END_MODULE:
+	case OP_DUP:
+	case OP_RETURN:
+	case OP_EXIT_MODULE:
+	case OP_NEW_STRUCT:
+	case OP_ROT_2:
+		return 0;
+
+	case OP_CONST_INT:
+	case OP_CONST_DOUBLE:
+	case OP_CONST_STRING:
+	case OP_CONST_CHAR:
+	case OP_JUMP:
+	case OP_JUMP_IF_TRUE:
+	case OP_JUMP_IF_FALSE:
+	case OP_LOAD_LOCAL:
+	case OP_STORE_LOCAL:
+	case OP_BIND_LOCAL:
+	case OP_BIND_UPVALUE:
+	case OP_LOAD_UPVALUE:
+	case OP_STORE_UPVALUE:
+	case OP_INIT_MODULE:
+	case OP_ENTER_MODULE:
+	case OP_NEW_ARRAY_WITH_VALUES:
+	case OP_CALL:
+	case OP_LOAD_GLOBAL:
+	case OP_DECLARE_GLOBAL:
+	case OP_STORE_GLOBAL:
+	case OP_LOAD_STRUCT:
+	case OP_STORE_STRUCT:
+	case OP_ADD_STRUCT_FIELD:
+		return 1;
+
+	case OP_NEW_FUNCTION:
+		return 6 + args[5];
+
+	case OP_LOAD_FROM_MODULE:
+		return 2;
+
+	case OP_NEW_STRUCT_SPEC:
+		return 2 + args[1];
+
+	default:
+		fprintf(stderr, "Unknown opcode: %d\n", op);
+		abort();
+	}
+}
+
+enum cb_opcode cb_opcode_assert(size_t n)
+{
+	switch (n) {
+#define CASE(OP) case OP: return OP;
+	CB_OPCODE_LIST(CASE)
+#undef CASE
+	default:
+		fprintf(stderr, "Invalid opcode: %zu\n", n);
+		abort();
+	}
 }

--- a/opcode.h
+++ b/opcode.h
@@ -1,6 +1,8 @@
 #ifndef cb_opcode_h
 #define cb_opcode_h
 
+#include "compiler.h"
+
 #define CB_OPCODE_LIST(X) \
 	X(OP_HALT) \
 	X(OP_CONST_INT) \
@@ -51,7 +53,6 @@
 	X(OP_INIT_MODULE) \
 	X(OP_END_MODULE) \
 	X(OP_DUP) \
-	X(OP_ALLOCATE_LOCALS) \
 	X(OP_ENTER_MODULE) \
 	X(OP_EXIT_MODULE) \
 	X(OP_NEW_STRUCT) \
@@ -69,5 +70,8 @@ enum cb_opcode {
 };
 
 const char *cb_opcode_name(enum cb_opcode);
+int cb_opcode_stack_effect(enum cb_opcode, cb_instruction *);
+unsigned cb_opcode_nargs(enum cb_opcode, cb_instruction *);
+enum cb_opcode cb_opcode_assert(size_t);
 
 #endif

--- a/repl.c
+++ b/repl.c
@@ -63,7 +63,7 @@ int cb_repl(void)
 			make_intrinsics(mod->global_scope);
 		}
 		frame.bp = 0;
-		frame.is_function = 0;
+		frame.func.type = CB_VALUE_NULL;
 		frame.module = NULL;
 		frame.parent = NULL;
 		result = cb_eval(&cb_vm_state, pc, &frame);

--- a/value.h
+++ b/value.h
@@ -67,6 +67,8 @@ struct cb_user_function {
 	struct cb_upvalue **upvalues;
 	size_t upvalues_size, upvalues_len;
 	size_t module_id;
+	size_t nlocals;
+	size_t stack_required;
 	struct cb_function_optargs optargs;
 };
 


### PR DESCRIPTION
Rather than checking if the stack should grow on every push.

Also puts the stack pointer on the stack to avoid extra pointer dereferences for every push/pop.